### PR TITLE
Fix multiple digit superscripting

### DIFF
--- a/src/response.py
+++ b/src/response.py
@@ -49,7 +49,7 @@ async def send_message(chatbot: Chatbot, message: discord.Interaction, user_mess
             # get reply text
             text = f"{reply['item']['messages'][1]['text']}"
             superscript_map = {'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴', '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹'}
-            text = re.sub(r'\[\^(\d+)\^\]', lambda match: superscript_map.get(match.group(1), match.group(0)), text)
+            text = re.sub(r'\[\^(\d+)\^\]', lambda match: ''.join(superscript_map.get(digit, digit) for digit in match.group(1)), text)
             # Get the URL, if available
             embed = ''
             if len(reply['item']['messages'][1]['sourceAttributions']) != 0:


### PR DESCRIPTION
Oops, noticed mutliple digit numbers weren't being superscripted:
![image](https://user-images.githubusercontent.com/126853352/228160729-d1e60f5e-c611-44e6-8fc7-549d87d1ca43.png)
Fixed now:
![2023-03-28-12-55-52](https://user-images.githubusercontent.com/126853352/228160815-04726b4a-29e5-4d54-b4ff-83c3067a852e.png)
Hopefully no other issues 😓