### PR TITLE
Add GitHub Actions Workflow for Deployment to GitHub Container Registry (GHCR)

### DIFF
--- a/.github/workflows/deploy-to-ghcr.yml
+++ b/.github/workflows/deploy-to-ghcr.yml
@@ -1,0 +1,43 @@
+name: "Deploy docker image to Github Container Registry"
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.actor }}/discordbot-edgegpt
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-to-ghcr.yml
+++ b/.github/workflows/deploy-to-ghcr.yml
@@ -21,7 +21,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.actor }}/discordbot-edgegpt
+          images: ghcr.io/${{ github.repository_owner }}/discordbot-edgegpt
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -32,7 +32,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  discord_edgegpt:
+    build: .
+    environment:
+      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
+    volumes:
+      - ./cookies.json:/bot/cookies.json
+      - ./config.yml:/bot/config.yml


### PR DESCRIPTION
# Description
This pull request introduces a new GitHub Actions workflow that automates the process of building and deploying 
Docker images to the GitHub Container Registry (GHCR). This workflow is triggered on every push and pull request to the `main` branch, as well as on the creation of a new tagged release. The workflow is designed to simplify and streamline the deployment process, making it easy to deploy `discordbot-edgegpt` application to Kubernetes or docker-compose environments.

# Changes
1. Added a new GitHub Actions workflow file `.github/workflows/deploy_to_ghcr.yml`.
2.. Configured the workflow to deploy images to GHCR with the `main` tag for pushes and pull requests to the `main` branch.
3. Configured the workflow to build semantic versioning for all tagged releases.

# Motivation
The motivation behind this change is to:

1. Automate the process of building and deploying Docker images for `discordbot-edgegpt` application.
2. Make it easy for developers and operators to deploy the application to Kubernetes or docker-compose environments by simply pulling the image from GHCR.

# Usage
To pull the `discordbot-edgegpt` image, simply run the following command:

```bash
docker pull ghcr.io/FuseFairy/discordbot-edgegpt:main
```
For deploying a specific version of the application, replace main with the desired semantic version tag (e.g., v1.0.0).

# Testing
The new GitHub Actions workflow has been tested on a separate repository and confirmed to be working as expected. See:
https://github.com/nqngo/DiscordBot-EdgeGPT
https://github.com/nqngo/DiscordBot-EdgeGPT/pkgs/container/discordbot-edgegpt