### PR TITLE
Fix uninitialized user chatbot in threads, typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .env
+.venv
 discord_bot.log
 test.py
 test2.py

--- a/cogs/event.py
+++ b/cogs/event.py
@@ -180,7 +180,7 @@ class Event(Cog_Extension):
                                 async with message.channel.typing():
                                     await send_message(message, chatbot, conversation_style_str, content, attachment.url)
                             else:
-                                await message.channel.send("> **ERROE：This file format is not supported.**")
+                                await message.channel.send("> **ERROR：This file format is not supported.**")
                     else:
                         logger.info(f"\x1b[31m{username}\x1b[0m：'{content}' ({channel}) [Style: {conversation_style_str}]")
                         async with message.channel.typing():
@@ -210,7 +210,7 @@ class Event(Cog_Extension):
                                 if "image" in attachment.content_type:
                                     await users_chatbot[user_id].send_message(message=content, image=attachment.url)
                                 else:
-                                    await message.channel.send("> **ERROE：This file format is not supported.**")
+                                    await message.channel.send("> **ERROR：This file format is not supported.**")
                         else:
                             await users_chatbot[user_id].send_message(message=content)
             except Exception as e:

--- a/cogs/event.py
+++ b/cogs/event.py
@@ -194,6 +194,10 @@ class Event(Cog_Extension):
                 if isinstance(message.channel, discord.Thread):
                     users_chatbot = get_users_chatbot()
                     user_id = message.author.id
+                    
+                    if user_id not in users_chatbot:
+                        return
+                    
                     user_thread = users_chatbot[user_id].get_thread()
                     username = str(message.author)
                     channel = str(message.channel)

--- a/src/user_chatbot.py
+++ b/src/user_chatbot.py
@@ -112,9 +112,9 @@ class UserChatbot():
             if interaction:
                 if not interaction.response.is_done():
                     await interaction.response.defer(thinking=True)
-                await interaction.followup.send("> **ERROE：Please wait for the previous command to complete.**")
+                await interaction.followup.send("> **ERROR：Please wait for the previous command to complete.**")
             else:
-                await self.thread.send("> **ERROE：Please wait for the previous command to complete.**")
+                await self.thread.send("> **ERROR：Please wait for the previous command to complete.**")
 
     async def create_image(self, interaction: discord.Interaction, prompt: str):
         if not self.sem_create_image.locked():
@@ -128,7 +128,7 @@ class UserChatbot():
         else:
             if not interaction.response.is_done():
                 await interaction.response.defer(thinking=True)
-            await interaction.followup.send("> **ERROE：Please wait for the previous command to complete.**")
+            await interaction.followup.send("> **ERROR：Please wait for the previous command to complete.**")
     
     async def reset_conversation(self):
         if self.jailbreak:


### PR DESCRIPTION
If the user didn't set up a thread before talking with the bot, there is a condition where the user chatbot wasn't initialised and would spit out errors when typing in any thread. Added a check so that doesn't happen.